### PR TITLE
Update .NET Core version to 10.0.x in workflow

### DIFF
--- a/.github/workflows/ShiftPayBackend.yml
+++ b/.github/workflows/ShiftPayBackend.yml
@@ -9,7 +9,7 @@ env:
   AZURE_WEBAPP_NAME: ShiftPayBackend
   AZURE_WEBAPP_PACKAGE_PATH: ShiftPay_Backend\publish
   CONFIGURATION: Release
-  DOTNET_CORE_VERSION: 9.0.x
+  DOTNET_CORE_VERSION: 10.0.x
   WORKING_DIRECTORY: ShiftPay_Backend
 
 jobs:


### PR DESCRIPTION
Bumps the DOTNET_CORE_VERSION from 9.0.x to 10.0.x in the GitHub Actions workflow for ShiftPayBackend to use the latest .NET Core version.