### PR TITLE
Refactor WorkInfo partition key to use UserId only

### DIFF
--- a/ShiftPay_Backend.Tests/ShiftPayTestFixture.cs
+++ b/ShiftPay_Backend.Tests/ShiftPayTestFixture.cs
@@ -151,7 +151,8 @@ public sealed class ShiftPayTestFixture : IAsyncLifetime
             },
         };
 
-        foreach (var shift in testShifts)
+		// Insert with conflict handling, since Cosmos may report conflicts if prior test runs left data.
+		foreach (var shift in testShifts)
         {
             try
             {
@@ -226,7 +227,8 @@ public sealed class ShiftPayTestFixture : IAsyncLifetime
             },
         };
 
-        foreach (var workInfo in testWorkInfos)
+		// Insert with conflict handling, similar to shifts.
+		foreach (var workInfo in testWorkInfos)
         {
             try
             {
@@ -239,7 +241,7 @@ public sealed class ShiftPayTestFixture : IAsyncLifetime
 
                 var existing = await _context.WorkInfos
                     .WithPartitionKey(workInfo.UserId)
-                    .FirstOrDefaultAsync(w => w.Id == workInfo.Id);
+                    .FirstOrDefaultAsync(w => w.Workplace == workInfo.Workplace);
 
                 if (existing is not null)
                 {

--- a/ShiftPay_Backend.Tests/ShiftPayTestFixture.cs
+++ b/ShiftPay_Backend.Tests/ShiftPayTestFixture.cs
@@ -238,8 +238,8 @@ public sealed class ShiftPayTestFixture : IAsyncLifetime
                 _context.ChangeTracker.Clear();
 
                 var existing = await _context.WorkInfos
-                    .WithPartitionKey(workInfo.UserId, workInfo.Workplace)
-                    .FirstOrDefaultAsync();
+                    .WithPartitionKey(workInfo.UserId)
+                    .FirstOrDefaultAsync(w => w.Id == workInfo.Id);
 
                 if (existing is not null)
                 {

--- a/ShiftPay_Backend/Controllers/WorkInfosController.cs
+++ b/ShiftPay_Backend/Controllers/WorkInfosController.cs
@@ -31,7 +31,6 @@ namespace ShiftPay_Backend.Controllers
 				return Unauthorized("User ID is missing.");
 			}
 
-			// Cosmos: WorkInfo partition key is (UserId, Workplace). Constrain to the UserId partition.
 			var workInfos = await _context.WorkInfos
 				.WithPartitionKey(userId)
 				.ToListAsync();
@@ -50,8 +49,8 @@ namespace ShiftPay_Backend.Controllers
 			}
 
 			var workInfo = await _context.WorkInfos
-				.WithPartitionKey(userId, workplace)
-				.FirstOrDefaultAsync();
+				.WithPartitionKey(userId)
+				.FirstOrDefaultAsync(workInfo => workInfo.Workplace == workplace);
 
 			if (workInfo == null)
 			{
@@ -73,10 +72,9 @@ namespace ShiftPay_Backend.Controllers
 				return Unauthorized("User ID is missing.");
 			}
 
-			// Cosmos: WorkInfo uses a composite partition key (UserId, Workplace)
 			var workInfo = await _context.WorkInfos
-				.WithPartitionKey(userId, workInfoDto.Workplace)
-				.FirstOrDefaultAsync();
+				.WithPartitionKey(userId)
+				.FirstOrDefaultAsync(workInfo => workInfo.Workplace == workInfoDto.Workplace);
 
 			if (workInfo == null)
 			{
@@ -104,10 +102,9 @@ namespace ShiftPay_Backend.Controllers
 				return Unauthorized("User ID is missing.");
 			}
 
-			// Cosmos: WorkInfo uses a composite partition key (UserId, Workplace)
 			var workInfo = await _context.WorkInfos
-				.WithPartitionKey(userId, workplace)
-				.FirstOrDefaultAsync();
+				.WithPartitionKey(userId)
+				.FirstOrDefaultAsync(workInfo => workInfo.Workplace == workplace);
 
 			if (payRate.HasValue)
 			{

--- a/ShiftPay_Backend/Data/ShiftPay_BackendContext.cs
+++ b/ShiftPay_Backend/Data/ShiftPay_BackendContext.cs
@@ -19,10 +19,10 @@ namespace ShiftPay_Backend.Data
                 .ToContainer("Shifts")
                 .HasPartitionKey(e => new { e.UserId, e.YearMonth, e.Day });
 
-            modelBuilder.Entity<WorkInfo>()
-                .ToContainer("WorkInfos")
-                .HasPartitionKey(e => new { e.UserId, e.Workplace });
-        }
+			modelBuilder.Entity<WorkInfo>()
+				.ToContainer("WorkInfos")
+				.HasPartitionKey(e => new { e.UserId });
+		}
 
         public DbSet<Shift> Shifts { get; set; } = default!;
         public DbSet<WorkInfo> WorkInfos { get; set; } = default!;

--- a/ShiftPay_Backend/Data/ShiftPay_BackendContext.cs
+++ b/ShiftPay_Backend/Data/ShiftPay_BackendContext.cs
@@ -21,7 +21,7 @@ namespace ShiftPay_Backend.Data
 
 			modelBuilder.Entity<WorkInfo>()
 				.ToContainer("WorkInfos")
-				.HasPartitionKey(e => new { e.UserId });
+				.HasPartitionKey(e => e.UserId);
 		}
 
         public DbSet<Shift> Shifts { get; set; } = default!;

--- a/ShiftPay_Backend/Models/Shift.cs
+++ b/ShiftPay_Backend/Models/Shift.cs
@@ -5,7 +5,7 @@ namespace ShiftPay_Backend.Models
     public class Shift
     {
         [JsonProperty(PropertyName = "id")]
-        public Guid Id { get; set; } = Guid.NewGuid();
+        public required Guid Id { get; set; } = Guid.NewGuid();
 
         public string UserId { get; set; } = string.Empty; // Partition Key 1
 

--- a/ShiftPay_Backend/Models/WorkInfo.cs
+++ b/ShiftPay_Backend/Models/WorkInfo.cs
@@ -5,11 +5,11 @@ namespace ShiftPay_Backend.Models
     public class WorkInfo
     {
         [JsonProperty(PropertyName = "id")]
-        public Guid Id { get; set; } = Guid.NewGuid();
+        public required Guid Id { get; set; } = Guid.NewGuid();
 
-        public required string UserId { get; set; } // Partition Key 1
+        public required string UserId { get; set; } // Partition Key
 
-        public required string Workplace { get; set; } // Partition Key 2
+        public required string Workplace { get; set; } // Unique Key (per UserId)
 
         public List<decimal> PayRates { get; set; } = new List<decimal>();
 
@@ -17,7 +17,6 @@ namespace ShiftPay_Backend.Models
         {
             return new WorkInfoDTO
             {
-                Id = this.Id,
                 Workplace = this.Workplace,
                 PayRates = new List<decimal>(this.PayRates)
             };
@@ -27,7 +26,7 @@ namespace ShiftPay_Backend.Models
         {
             return new WorkInfo
             {
-                Id = dto.Id ?? Guid.NewGuid(),
+                Id = Guid.NewGuid(),
                 UserId = userId,
                 Workplace = dto.Workplace,
                 PayRates = new List<decimal>(dto.PayRates)
@@ -37,8 +36,6 @@ namespace ShiftPay_Backend.Models
 
     public class WorkInfoDTO
     {
-        public Guid? Id { get; set; }
-
         public required string Workplace { get; set; }
 
         public List<decimal> PayRates { get; set; } = new List<decimal>();


### PR DESCRIPTION
Updated the WorkInfo entity and related queries to use only UserId as the partition key instead of a composite key with Workplace. Adjusted controller logic, test fixtures, and model definitions to align with this change. Also removed Id from WorkInfoDTO and made Id a required property in Shift and WorkInfo models.