### PR TITLE
Add Cosmos DB unique key and partition tests, improve test isolation

### DIFF
--- a/ShiftPay_Backend.Tests/AuthenticatedIntegrationTests.cs
+++ b/ShiftPay_Backend.Tests/AuthenticatedIntegrationTests.cs
@@ -16,7 +16,7 @@ public class AuthenticatedIntegrationTests : IAsyncLifetime
 	private HttpClient? _httpClient;
 	private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(60);
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		// Set environment to Test to enable fake auth before creating the builder
 		Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Test");
@@ -48,7 +48,7 @@ public class AuthenticatedIntegrationTests : IAsyncLifetime
 			.WaitForResourceAsync("shiftpay-backend", KnownResourceStates.Running, cts.Token);
 	}
 
-	public async Task DisposeAsync()
+	public async ValueTask DisposeAsync()
 	{
 		_httpClient?.Dispose();
 		if (_app is not null)

--- a/ShiftPay_Backend.Tests/CosmosDbTestFixture.cs
+++ b/ShiftPay_Backend.Tests/CosmosDbTestFixture.cs
@@ -7,113 +7,131 @@ namespace ShiftPay_Backend.Tests;
 
 /// <summary>
 /// Shared test fixture that initializes a single Cosmos DB connection for all tests.
-/// Uses the Azure Cosmos DB Emulator with the "ShiftPay" database.
+/// Uses the Azure Cosmos DB Emulator with the "ShiftPay_Test" database.
+/// The database is deleted and recreated at the start of each test run.
 /// </summary>
 public class CosmosDbTestFixture : IAsyncLifetime
 {
-	private const string EmulatorEndpoint = "https://localhost:8081/";
-	private const string EmulatorKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
-	private const string DatabaseName = "ShiftPay";
+    private const string EmulatorEndpoint = "https://localhost:8081/";
+    private const string EmulatorKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+    private const string DatabaseName = "ShiftPay_Test"; // Use separate database for tests
 
-	private CosmosClient? _cosmosClient;
+    private CosmosClient? _cosmosClient;
 
-	public ShiftPay_BackendContext CreateContext()
-	{
-		var configuration = new ConfigurationBuilder()
-			.AddInMemoryCollection(new Dictionary<string, string?>
-			{
-				["Cosmos:Endpoint"] = EmulatorEndpoint,
-				["Cosmos:Key"] = EmulatorKey,
-				["Cosmos:DatabaseName"] = DatabaseName
-			})
-			.Build();
+    public ShiftPay_BackendContext CreateContext()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Cosmos:Endpoint"] = EmulatorEndpoint,
+                ["Cosmos:Key"] = EmulatorKey,
+                ["Cosmos:DatabaseName"] = DatabaseName
+            })
+            .Build();
 
-		var options = new DbContextOptionsBuilder<ShiftPay_BackendContext>()
-			.UseCosmos(EmulatorEndpoint, EmulatorKey, DatabaseName, cosmosOptions =>
-			{
-				cosmosOptions.HttpClientFactory(() =>
-				{
-					// Disable SSL validation for emulator
-					var handler = new HttpClientHandler
-					{
-						ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-					};
-					return new HttpClient(handler);
-				});
-				cosmosOptions.ConnectionMode(ConnectionMode.Gateway);
-			})
-			.Options;
+        var options = new DbContextOptionsBuilder<ShiftPay_BackendContext>()
+            .UseCosmos(EmulatorEndpoint, EmulatorKey, DatabaseName, cosmosOptions =>
+            {
+                cosmosOptions.HttpClientFactory(() =>
+                {
+                    // Disable SSL validation for emulator
+                    var handler = new HttpClientHandler
+                    {
+                        ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+                    };
+                    return new HttpClient(handler);
+                });
+                cosmosOptions.ConnectionMode(ConnectionMode.Gateway);
+            })
+            .Options;
 
-		return new ShiftPay_BackendContext(options, configuration);
-	}
+        return new ShiftPay_BackendContext(options, configuration);
+    }
 
-	public async Task InitializeAsync()
-	{
-		// Create the Cosmos client with emulator settings
-		var cosmosClientOptions = new CosmosClientOptions
-		{
-			HttpClientFactory = () =>
-			{
-				var handler = new HttpClientHandler
-				{
-					ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-				};
-				return new HttpClient(handler);
-			},
-			ConnectionMode = ConnectionMode.Gateway
-		};
+    public async Task InitializeAsync()
+    {
+        // Create the Cosmos client with emulator settings
+        var cosmosClientOptions = new CosmosClientOptions
+        {
+            HttpClientFactory = () =>
+            {
+                var handler = new HttpClientHandler
+                {
+                    ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+                };
+                return new HttpClient(handler);
+            },
+            ConnectionMode = ConnectionMode.Gateway
+        };
 
-		_cosmosClient = new CosmosClient(EmulatorEndpoint, EmulatorKey, cosmosClientOptions);
+        _cosmosClient = new CosmosClient(EmulatorEndpoint, EmulatorKey, cosmosClientOptions);
 
-		// Create database if it doesn't exist
-		var databaseResponse = await _cosmosClient.CreateDatabaseIfNotExistsAsync(DatabaseName);
-		var database = databaseResponse.Database;
+        // Delete the database if it exists to ensure clean state
+        // This also ensures unique key policies are properly applied (they can only be set at creation)
+        try
+        {
+            var existingDatabase = _cosmosClient.GetDatabase(DatabaseName);
+            await existingDatabase.DeleteAsync();
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            // Database doesn't exist, that's fine
+        }
 
-		// Create containers if they don't exist
-		await database.CreateContainerIfNotExistsAsync(new ContainerProperties("Shifts", new[] { "/UserId", "/YearMonth", "/Day" }));
-		await database.CreateContainerIfNotExistsAsync(new ContainerProperties("WorkInfos", new[] { "/UserId" }));
-		await database.CreateContainerIfNotExistsAsync(new ContainerProperties("ShiftTemplates", new[] { "/UserId" }));
+        // Create fresh database
+        var databaseResponse = await _cosmosClient.CreateDatabaseAsync(DatabaseName);
+        var database = databaseResponse.Database;
 
-		// Ensure EF Core schema is created
-		await using var context = CreateContext();
-		await context.Database.EnsureCreatedAsync();
-	}
+        // Create containers with partition keys and unique key policies
+        // Note: Unique keys are scoped within a partition
 
-	public async Task DisposeAsync()
-	{
-		_cosmosClient?.Dispose();
-		await Task.CompletedTask;
-	}
+        // Shifts container - no unique key needed (Id is unique)
+        await database.CreateContainerAsync(
+            new ContainerProperties("Shifts", ["/UserId", "/YearMonth", "/Day"]));
 
-	/// <summary>
-	/// Cleans up test data for a specific user ID.
-	/// Call this in test cleanup to isolate test data.
-	/// </summary>
-	public async Task CleanupUserDataAsync(string userId)
-	{
-		await using var context = CreateContext();
+        // WorkInfos container - Workplace should be unique per user (partition)
+        var workInfosProperties = new ContainerProperties("WorkInfos", ["/UserId"])
+        {
+            UniqueKeyPolicy = new UniqueKeyPolicy
+            {
+                UniqueKeys =
+                {
+                    new UniqueKey { Paths = { "/Workplace" } }
+                }
+            }
+        };
+        await database.CreateContainerAsync(workInfosProperties);
 
-		var shifts = await context.Shifts
-			.Where(s => s.UserId == userId)
-			.ToListAsync();
-		context.Shifts.RemoveRange(shifts);
+        // ShiftTemplates container - TemplateName should be unique per user (partition)
+        var shiftTemplatesProperties = new ContainerProperties("ShiftTemplates", ["/UserId"])
+        {
+            UniqueKeyPolicy = new UniqueKeyPolicy
+            {
+                UniqueKeys =
+                {
+                    new UniqueKey { Paths = { "/TemplateName" } }
+                }
+            }
+        };
+        await database.CreateContainerAsync(shiftTemplatesProperties);
 
-		var workInfos = await context.WorkInfos
-			.Where(w => w.UserId == userId)
-			.ToListAsync();
-		context.WorkInfos.RemoveRange(workInfos);
+        // Ensure EF Core schema is created
+        await using var context = CreateContext();
+        await context.Database.EnsureCreatedAsync();
+    }
 
-		var shiftTemplates = await context.ShiftTemplates
-			.Where(st => st.UserId == userId)
-			.ToListAsync();
-		context.ShiftTemplates.RemoveRange(shiftTemplates);
-
-		await context.SaveChangesAsync();
-	}
+    public async Task DisposeAsync()
+    {
+        _cosmosClient?.Dispose();
+        await Task.CompletedTask;
+    }
 }
 
 /// <summary>
 /// Collection definition for sharing the CosmosDbTestFixture across all test classes.
+/// The fixture is initialized once per test run, which deletes and recreates the database.
+/// Each test class instance gets a unique user ID (via Guid) to ensure test isolation
+/// without needing per-test cleanup.
 /// </summary>
 [CollectionDefinition("CosmosDb")]
 public class CosmosDbCollection : ICollectionFixture<CosmosDbTestFixture>

--- a/ShiftPay_Backend.Tests/CosmosDbTestFixture.cs
+++ b/ShiftPay_Backend.Tests/CosmosDbTestFixture.cs
@@ -12,119 +12,119 @@ namespace ShiftPay_Backend.Tests;
 /// </summary>
 public class CosmosDbTestFixture : IAsyncLifetime
 {
-    private const string EmulatorEndpoint = "https://localhost:8081/";
-    private const string EmulatorKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
-    private const string DatabaseName = "ShiftPay_Test"; // Use separate database for tests
+	private const string EmulatorEndpoint = "https://localhost:8081/";
+	private const string EmulatorKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+	private const string DatabaseName = "ShiftPay_Test"; // Use separate database for tests
 
-    private CosmosClient? _cosmosClient;
+	private CosmosClient? _cosmosClient;
 
-    public ShiftPay_BackendContext CreateContext()
-    {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Cosmos:Endpoint"] = EmulatorEndpoint,
-                ["Cosmos:Key"] = EmulatorKey,
-                ["Cosmos:DatabaseName"] = DatabaseName
-            })
-            .Build();
+	public ShiftPay_BackendContext CreateContext()
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				["Cosmos:Endpoint"] = EmulatorEndpoint,
+				["Cosmos:Key"] = EmulatorKey,
+				["Cosmos:DatabaseName"] = DatabaseName
+			})
+			.Build();
 
-        var options = new DbContextOptionsBuilder<ShiftPay_BackendContext>()
-            .UseCosmos(EmulatorEndpoint, EmulatorKey, DatabaseName, cosmosOptions =>
-            {
-                cosmosOptions.HttpClientFactory(() =>
-                {
-                    // Disable SSL validation for emulator
-                    var handler = new HttpClientHandler
-                    {
-                        ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-                    };
-                    return new HttpClient(handler);
-                });
-                cosmosOptions.ConnectionMode(ConnectionMode.Gateway);
-            })
-            .Options;
+		var options = new DbContextOptionsBuilder<ShiftPay_BackendContext>()
+			.UseCosmos(EmulatorEndpoint, EmulatorKey, DatabaseName, cosmosOptions =>
+			{
+				cosmosOptions.HttpClientFactory(() =>
+				{
+					// Disable SSL validation for emulator
+					var handler = new HttpClientHandler
+					{
+						ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+					};
+					return new HttpClient(handler);
+				});
+				cosmosOptions.ConnectionMode(ConnectionMode.Gateway);
+			})
+			.Options;
 
-        return new ShiftPay_BackendContext(options, configuration);
-    }
+		return new ShiftPay_BackendContext(options, configuration);
+	}
 
-    public async Task InitializeAsync()
-    {
-        // Create the Cosmos client with emulator settings
-        var cosmosClientOptions = new CosmosClientOptions
-        {
-            HttpClientFactory = () =>
-            {
-                var handler = new HttpClientHandler
-                {
-                    ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-                };
-                return new HttpClient(handler);
-            },
-            ConnectionMode = ConnectionMode.Gateway
-        };
+	public async ValueTask InitializeAsync()
+	{
+		// Create the Cosmos client with emulator settings
+		var cosmosClientOptions = new CosmosClientOptions
+		{
+			HttpClientFactory = () =>
+			{
+				var handler = new HttpClientHandler
+				{
+					ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+				};
+				return new HttpClient(handler);
+			},
+			ConnectionMode = ConnectionMode.Gateway
+		};
 
-        _cosmosClient = new CosmosClient(EmulatorEndpoint, EmulatorKey, cosmosClientOptions);
+		_cosmosClient = new CosmosClient(EmulatorEndpoint, EmulatorKey, cosmosClientOptions);
 
-        // Delete the database if it exists to ensure clean state
-        // This also ensures unique key policies are properly applied (they can only be set at creation)
-        try
-        {
-            var existingDatabase = _cosmosClient.GetDatabase(DatabaseName);
-            await existingDatabase.DeleteAsync();
-        }
-        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
-        {
-            // Database doesn't exist, that's fine
-        }
+		// Delete the database if it exists to ensure clean state
+		// This also ensures unique key policies are properly applied (they can only be set at creation)
+		try
+		{
+			var existingDatabase = _cosmosClient.GetDatabase(DatabaseName);
+			await existingDatabase.DeleteAsync();
+		}
+		catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+		{
+			// Database doesn't exist, that's fine
+		}
 
-        // Create fresh database
-        var databaseResponse = await _cosmosClient.CreateDatabaseAsync(DatabaseName);
-        var database = databaseResponse.Database;
+		// Create fresh database
+		var databaseResponse = await _cosmosClient.CreateDatabaseAsync(DatabaseName);
+		var database = databaseResponse.Database;
 
-        // Create containers with partition keys and unique key policies
-        // Note: Unique keys are scoped within a partition
+		// Create containers with partition keys and unique key policies
+		// Note: Unique keys are scoped within a partition
 
-        // Shifts container - no unique key needed (Id is unique)
-        await database.CreateContainerAsync(
-            new ContainerProperties("Shifts", ["/UserId", "/YearMonth", "/Day"]));
+		// Shifts container - no unique key needed (Id is unique)
+		await database.CreateContainerAsync(
+			new ContainerProperties("Shifts", ["/UserId", "/YearMonth", "/Day"]));
 
-        // WorkInfos container - Workplace should be unique per user (partition)
-        var workInfosProperties = new ContainerProperties("WorkInfos", ["/UserId"])
-        {
-            UniqueKeyPolicy = new UniqueKeyPolicy
-            {
-                UniqueKeys =
-                {
-                    new UniqueKey { Paths = { "/Workplace" } }
-                }
-            }
-        };
-        await database.CreateContainerAsync(workInfosProperties);
+		// WorkInfos container - Workplace should be unique per user (partition)
+		var workInfosProperties = new ContainerProperties("WorkInfos", ["/UserId"])
+		{
+			UniqueKeyPolicy = new UniqueKeyPolicy
+			{
+				UniqueKeys =
+				{
+					new UniqueKey { Paths = { "/Workplace" } }
+				}
+			}
+		};
+		await database.CreateContainerAsync(workInfosProperties);
 
-        // ShiftTemplates container - TemplateName should be unique per user (partition)
-        var shiftTemplatesProperties = new ContainerProperties("ShiftTemplates", ["/UserId"])
-        {
-            UniqueKeyPolicy = new UniqueKeyPolicy
-            {
-                UniqueKeys =
-                {
-                    new UniqueKey { Paths = { "/TemplateName" } }
-                }
-            }
-        };
-        await database.CreateContainerAsync(shiftTemplatesProperties);
+		// ShiftTemplates container - TemplateName should be unique per user (partition)
+		var shiftTemplatesProperties = new ContainerProperties("ShiftTemplates", ["/UserId"])
+		{
+			UniqueKeyPolicy = new UniqueKeyPolicy
+			{
+				UniqueKeys =
+				{
+					new UniqueKey { Paths = { "/TemplateName" } }
+				}
+			}
+		};
+		await database.CreateContainerAsync(shiftTemplatesProperties);
 
-        // Ensure EF Core schema is created
-        await using var context = CreateContext();
-        await context.Database.EnsureCreatedAsync();
-    }
+		// Ensure EF Core schema is created
+		await using var context = CreateContext();
+		await context.Database.EnsureCreatedAsync();
+	}
 
-    public async Task DisposeAsync()
-    {
-        _cosmosClient?.Dispose();
-        await Task.CompletedTask;
-    }
+	public ValueTask DisposeAsync()
+	{
+		_cosmosClient?.Dispose();
+		return ValueTask.CompletedTask;
+	}
 }
 
 /// <summary>

--- a/ShiftPay_Backend.Tests/DatabaseInfrastructureTests.cs
+++ b/ShiftPay_Backend.Tests/DatabaseInfrastructureTests.cs
@@ -1,0 +1,337 @@
+using Microsoft.Azure.Cosmos;
+using Microsoft.EntityFrameworkCore;
+using ShiftPay_Backend.Models;
+
+namespace ShiftPay_Backend.Tests;
+
+/// <summary>
+/// Tests that verify the Cosmos DB database infrastructure is set up correctly.
+/// These tests run first to ensure containers have proper unique key constraints.
+/// </summary>
+[Collection("CosmosDb")]
+public class DatabaseInfrastructureTests
+{
+    private readonly CosmosDbTestFixture _fixture;
+
+    public DatabaseInfrastructureTests(CosmosDbTestFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    #region Container Existence Tests
+
+    [Fact]
+    public async Task Database_ShiftsContainer_Exists()
+    {
+        // Arrange
+        await using var context = _fixture.CreateContext();
+
+        // Act & Assert - Should not throw
+        var shifts = await context.Shifts.Take(1).ToListAsync();
+        Assert.NotNull(shifts);
+    }
+
+    [Fact]
+    public async Task Database_WorkInfosContainer_Exists()
+    {
+        // Arrange
+        await using var context = _fixture.CreateContext();
+
+        // Act & Assert - Should not throw
+        var workInfos = await context.WorkInfos.Take(1).ToListAsync();
+        Assert.NotNull(workInfos);
+    }
+
+    [Fact]
+    public async Task Database_ShiftTemplatesContainer_Exists()
+    {
+        // Arrange
+        await using var context = _fixture.CreateContext();
+
+        // Act & Assert - Should not throw
+        var templates = await context.ShiftTemplates.Take(1).ToListAsync();
+        Assert.NotNull(templates);
+    }
+
+    #endregion
+
+    #region Unique Key Constraint Tests - ShiftTemplates
+
+    [Fact]
+    public async Task ShiftTemplates_DuplicateTemplateName_SameUser_ThrowsConflict()
+    {
+        // Arrange - Unique key on /TemplateName within partition (userId)
+        var userId = $"db-unique-test-{Guid.NewGuid():N}";
+        await using var context = _fixture.CreateContext();
+
+        var template1 = new ShiftTemplate
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            TemplateName = "Duplicate Template Name",
+            Workplace = "Workplace 1",
+            PayRate = 15.00m,
+            StartTime = new DateTime(2024, 1, 1, 9, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2024, 1, 1, 17, 0, 0, DateTimeKind.Utc),
+            UnpaidBreaks = []
+        };
+
+        var template2 = new ShiftTemplate
+        {
+            Id = Guid.NewGuid(), // Different ID
+            UserId = userId,     // Same user (partition)
+            TemplateName = "Duplicate Template Name", // Same name - should violate unique key
+            Workplace = "Workplace 2",
+            PayRate = 20.00m,
+            StartTime = new DateTime(2024, 1, 1, 10, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2024, 1, 1, 18, 0, 0, DateTimeKind.Utc),
+            UnpaidBreaks = []
+        };
+
+        // Act
+        context.ShiftTemplates.Add(template1);
+        await context.SaveChangesAsync();
+
+        context.ShiftTemplates.Add(template2);
+
+        // Assert - Should throw due to unique key constraint violation
+        var exception = await Assert.ThrowsAsync<DbUpdateException>(
+            () => context.SaveChangesAsync());
+
+        // Verify it's a Cosmos conflict (409) error
+        Assert.Contains("Conflict", exception.InnerException?.Message ?? exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ShiftTemplates_DuplicateTemplateName_DifferentUsers_Succeeds()
+    {
+        // Arrange - Unique key is scoped to partition, so different users can have same template name
+        var userId1 = $"db-unique-user1-{Guid.NewGuid():N}";
+        var userId2 = $"db-unique-user2-{Guid.NewGuid():N}";
+        await using var context = _fixture.CreateContext();
+
+        var template1 = new ShiftTemplate
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId1,
+            TemplateName = "Shared Template Name",
+            Workplace = "Workplace",
+            PayRate = 15.00m,
+            StartTime = new DateTime(2024, 1, 1, 9, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2024, 1, 1, 17, 0, 0, DateTimeKind.Utc),
+            UnpaidBreaks = []
+        };
+
+        var template2 = new ShiftTemplate
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId2, // Different user (different partition)
+            TemplateName = "Shared Template Name", // Same name - OK in different partition
+            Workplace = "Workplace",
+            PayRate = 20.00m,
+            StartTime = new DateTime(2024, 1, 1, 10, 0, 0, DateTimeKind.Utc),
+            EndTime = new DateTime(2024, 1, 1, 18, 0, 0, DateTimeKind.Utc),
+            UnpaidBreaks = []
+        };
+
+        // Act & Assert - Should succeed
+        context.ShiftTemplates.Add(template1);
+        await context.SaveChangesAsync();
+
+        context.ShiftTemplates.Add(template2);
+        await context.SaveChangesAsync(); // Should not throw
+
+        // Verify both exist
+        var count1 = await context.ShiftTemplates.CountAsync(t => t.UserId == userId1);
+        var count2 = await context.ShiftTemplates.CountAsync(t => t.UserId == userId2);
+        Assert.Equal(1, count1);
+        Assert.Equal(1, count2);
+    }
+
+    #endregion
+
+    #region Unique Key Constraint Tests - WorkInfos
+
+    [Fact]
+    public async Task WorkInfos_DuplicateWorkplace_SameUser_ThrowsConflict()
+    {
+        // Arrange - Unique key on /Workplace within partition (userId)
+        var userId = $"db-workinfo-unique-{Guid.NewGuid():N}";
+        await using var context = _fixture.CreateContext();
+
+        var workInfo1 = new WorkInfo
+        {
+            Id = $"workinfo-{Guid.NewGuid():N}",
+            UserId = userId,
+            Workplace = "Duplicate Workplace",
+            PayRates = [15.00m]
+        };
+
+        var workInfo2 = new WorkInfo
+        {
+            Id = $"workinfo-{Guid.NewGuid():N}", // Different ID
+            UserId = userId,     // Same user (partition)
+            Workplace = "Duplicate Workplace", // Same workplace - should violate unique key
+            PayRates = [20.00m]
+        };
+
+        // Act
+        context.WorkInfos.Add(workInfo1);
+        await context.SaveChangesAsync();
+
+        context.WorkInfos.Add(workInfo2);
+
+        // Assert - Should throw due to unique key constraint violation
+        var exception = await Assert.ThrowsAsync<DbUpdateException>(
+            () => context.SaveChangesAsync());
+
+        // Verify it's a Cosmos conflict (409) error
+        Assert.Contains("Conflict", exception.InnerException?.Message ?? exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task WorkInfos_DuplicateWorkplace_DifferentUsers_Succeeds()
+    {
+        // Arrange - Unique key is scoped to partition, so different users can have same workplace
+        var userId1 = $"db-workinfo-user1-{Guid.NewGuid():N}";
+        var userId2 = $"db-workinfo-user2-{Guid.NewGuid():N}";
+        await using var context = _fixture.CreateContext();
+
+        var workInfo1 = new WorkInfo
+        {
+            Id = $"workinfo-{Guid.NewGuid():N}",
+            UserId = userId1,
+            Workplace = "Shared Workplace",
+            PayRates = [15.00m]
+        };
+
+        var workInfo2 = new WorkInfo
+        {
+            Id = $"workinfo-{Guid.NewGuid():N}",
+            UserId = userId2, // Different user (different partition)
+            Workplace = "Shared Workplace", // Same workplace - OK in different partition
+            PayRates = [20.00m]
+        };
+
+        // Act & Assert - Should succeed
+        context.WorkInfos.Add(workInfo1);
+        await context.SaveChangesAsync();
+
+        context.WorkInfos.Add(workInfo2);
+        await context.SaveChangesAsync(); // Should not throw
+
+        // Verify both exist
+        var count1 = await context.WorkInfos.CountAsync(w => w.UserId == userId1);
+        var count2 = await context.WorkInfos.CountAsync(w => w.UserId == userId2);
+        Assert.Equal(1, count1);
+        Assert.Equal(1, count2);
+    }
+
+    #endregion
+
+    #region Partition Key Tests
+
+    [Fact]
+    public async Task Shifts_HierarchicalPartitionKey_WorksCorrectly()
+    {
+        // Arrange - Shifts use hierarchical partition key: /UserId, /YearMonth, /Day
+        var userId = $"db-partition-test-{Guid.NewGuid():N}";
+        await using var context = _fixture.CreateContext();
+
+        var shift1 = new Shift
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Workplace = "Test",
+            PayRate = 20.00m,
+            StartTime = new DateTime(2024, 6, 15, 9, 0, 0, DateTimeKind.Utc), // June 15
+            EndTime = new DateTime(2024, 6, 15, 17, 0, 0, DateTimeKind.Utc),
+            UnpaidBreaks = []
+        };
+
+        var shift2 = new Shift
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Workplace = "Test",
+            PayRate = 22.00m,
+            StartTime = new DateTime(2024, 7, 20, 9, 0, 0, DateTimeKind.Utc), // July 20 (different partition)
+            EndTime = new DateTime(2024, 7, 20, 17, 0, 0, DateTimeKind.Utc),
+            UnpaidBreaks = []
+        };
+
+        // Act
+        context.Shifts.Add(shift1);
+        context.Shifts.Add(shift2);
+        await context.SaveChangesAsync();
+
+        // Assert - Both should be queryable
+        var allShifts = await context.Shifts
+            .Where(s => s.UserId == userId)
+            .ToListAsync();
+
+        Assert.Equal(2, allShifts.Count);
+        Assert.Contains(allShifts, s => s.YearMonth == "2024-06" && s.Day == 15);
+        Assert.Contains(allShifts, s => s.YearMonth == "2024-07" && s.Day == 20);
+    }
+
+    #endregion
+
+    #region ETag Concurrency Tests
+
+    [Fact]
+    public async Task Shifts_ETagConcurrency_IsEnabled()
+    {
+        // Arrange - This test verifies that EF Core concurrency control with ETags is working
+        // The ETag property may not be directly visible but concurrency checks should still work
+        var userId = $"db-etag-test-{Guid.NewGuid():N}";
+        var shiftId = Guid.NewGuid();
+        var startTime = new DateTime(2024, 8, 1, 9, 0, 0, DateTimeKind.Utc);
+
+        // Create the shift
+        await using (var createContext = _fixture.CreateContext())
+        {
+            var shift = new Shift
+            {
+                Id = shiftId,
+                UserId = userId,
+                Workplace = "ETag Test",
+                PayRate = 20.00m,
+                StartTime = startTime,
+                EndTime = new DateTime(2024, 8, 1, 17, 0, 0, DateTimeKind.Utc),
+                UnpaidBreaks = []
+            };
+
+            createContext.Shifts.Add(shift);
+            await createContext.SaveChangesAsync();
+        }
+
+        // Load in context1 (fresh context)
+        await using var context1 = _fixture.CreateContext();
+        var loaded1 = await context1.Shifts
+            .Where(s => s.Id == shiftId && s.UserId == userId)
+            .FirstOrDefaultAsync();
+        Assert.NotNull(loaded1);
+
+        // Load in context2
+        await using var context2 = _fixture.CreateContext();
+        var loaded2 = await context2.Shifts
+            .Where(s => s.Id == shiftId && s.UserId == userId)
+            .FirstOrDefaultAsync();
+        Assert.NotNull(loaded2);
+
+        // Modify in context2 first - this changes the ETag in Cosmos DB
+        loaded2.PayRate = 25.00m;
+        await context2.SaveChangesAsync();
+
+        // Now try to modify in context1 (has stale ETag from when it was loaded)
+        loaded1.PayRate = 30.00m;
+
+        // Assert - Should throw DbUpdateConcurrencyException due to ETag mismatch
+        // This proves that UseETagConcurrency() is working
+        await Assert.ThrowsAsync<DbUpdateConcurrencyException>(
+            () => context1.SaveChangesAsync());
+    }
+
+    #endregion
+}

--- a/ShiftPay_Backend.Tests/DatabaseInfrastructureTests.cs
+++ b/ShiftPay_Backend.Tests/DatabaseInfrastructureTests.cs
@@ -11,353 +11,353 @@ namespace ShiftPay_Backend.Tests;
 [Collection("CosmosDb")]
 public class DatabaseInfrastructureTests
 {
-    private readonly CosmosDbTestFixture _fixture;
+	private readonly CosmosDbTestFixture _fixture;
 
-    public DatabaseInfrastructureTests(CosmosDbTestFixture fixture)
-    {
-        _fixture = fixture;
-    }
+	public DatabaseInfrastructureTests(CosmosDbTestFixture fixture)
+	{
+		_fixture = fixture;
+	}
 
-    #region Container Existence Tests
+	#region Container Existence Tests
 
-    [Fact]
-    public async Task Database_ShiftsContainer_Exists()
-    {
-        // Arrange
-        await using var context = _fixture.CreateContext();
+	[Fact]
+	public async Task Database_ShiftsContainer_Exists()
+	{
+		// Arrange
+		await using var context = _fixture.CreateContext();
 
-        // Act & Assert - Should not throw
-        var shifts = await context.Shifts.Take(1).ToListAsync();
-        Assert.NotNull(shifts);
-    }
+		// Act & Assert - Should not throw
+		var shifts = await context.Shifts.Take(1).ToListAsync();
+		Assert.NotNull(shifts);
+	}
 
-    [Fact]
-    public async Task Database_WorkInfosContainer_Exists()
-    {
-        // Arrange
-        await using var context = _fixture.CreateContext();
+	[Fact]
+	public async Task Database_WorkInfosContainer_Exists()
+	{
+		// Arrange
+		await using var context = _fixture.CreateContext();
 
-        // Act & Assert - Should not throw
-        var workInfos = await context.WorkInfos.Take(1).ToListAsync();
-        Assert.NotNull(workInfos);
-    }
+		// Act & Assert - Should not throw
+		var workInfos = await context.WorkInfos.Take(1).ToListAsync();
+		Assert.NotNull(workInfos);
+	}
 
-    [Fact]
-    public async Task Database_ShiftTemplatesContainer_Exists()
-    {
-        // Arrange
-        await using var context = _fixture.CreateContext();
+	[Fact]
+	public async Task Database_ShiftTemplatesContainer_Exists()
+	{
+		// Arrange
+		await using var context = _fixture.CreateContext();
 
-        // Act & Assert - Should not throw
-        var templates = await context.ShiftTemplates.Take(1).ToListAsync();
-        Assert.NotNull(templates);
-    }
+		// Act & Assert - Should not throw
+		var templates = await context.ShiftTemplates.Take(1).ToListAsync();
+		Assert.NotNull(templates);
+	}
 
-    #endregion
+	#endregion
 
-    #region Unique Key Constraint Tests - ShiftTemplates
+	#region Unique Key Constraint Tests - ShiftTemplates
 
-    [Fact]
-    public async Task ShiftTemplates_DuplicateTemplateName_SameUser_ThrowsConflict()
-    {
-        // Arrange - Unique key on /TemplateName within partition (userId)
-        var userId = $"db-unique-test-{Guid.NewGuid():N}";
-        await using var context = _fixture.CreateContext();
+	[Fact]
+	public async Task ShiftTemplates_DuplicateTemplateName_SameUser_ThrowsConflict()
+	{
+		// Arrange - Unique key on /TemplateName within partition (userId)
+		var userId = $"db-unique-test-{Guid.NewGuid():N}";
+		await using var context = _fixture.CreateContext();
 
-        var template1 = new ShiftTemplate
-        {
-            Id = Guid.NewGuid(),
-            UserId = userId,
-            TemplateName = "Duplicate Template Name",
-            Workplace = "Workplace 1",
-            PayRate = 15.00m,
-            StartTime = new DateTime(2024, 1, 1, 9, 0, 0, DateTimeKind.Utc),
-            EndTime = new DateTime(2024, 1, 1, 17, 0, 0, DateTimeKind.Utc),
-            UnpaidBreaks = []
-        };
+		var template1 = new ShiftTemplate
+		{
+			Id = Guid.NewGuid(),
+			UserId = userId,
+			TemplateName = "Duplicate Template Name",
+			Workplace = "Workplace 1",
+			PayRate = 15.00m,
+			StartTime = new DateTime(2024, 1, 1, 9, 0, 0, DateTimeKind.Utc),
+			EndTime = new DateTime(2024, 1, 1, 17, 0, 0, DateTimeKind.Utc),
+			UnpaidBreaks = []
+		};
 
-        var template2 = new ShiftTemplate
-        {
-            Id = Guid.NewGuid(), // Different ID
-            UserId = userId,     // Same user (partition)
-            TemplateName = "Duplicate Template Name", // Same name - should violate unique key
-            Workplace = "Workplace 2",
-            PayRate = 20.00m,
-            StartTime = new DateTime(2024, 1, 1, 10, 0, 0, DateTimeKind.Utc),
-            EndTime = new DateTime(2024, 1, 1, 18, 0, 0, DateTimeKind.Utc),
-            UnpaidBreaks = []
-        };
+		var template2 = new ShiftTemplate
+		{
+			Id = Guid.NewGuid(), // Different ID
+			UserId = userId,     // Same user (partition)
+			TemplateName = "Duplicate Template Name", // Same name - should violate unique key
+			Workplace = "Workplace 2",
+			PayRate = 20.00m,
+			StartTime = new DateTime(2024, 1, 1, 10, 0, 0, DateTimeKind.Utc),
+			EndTime = new DateTime(2024, 1, 1, 18, 0, 0, DateTimeKind.Utc),
+			UnpaidBreaks = []
+		};
 
-        // Act
-        context.ShiftTemplates.Add(template1);
-        await context.SaveChangesAsync();
+		// Act
+		context.ShiftTemplates.Add(template1);
+		await context.SaveChangesAsync();
 
-        context.ShiftTemplates.Add(template2);
+		context.ShiftTemplates.Add(template2);
 
-        // Assert - Should throw due to unique key constraint violation
-        var exception = await Assert.ThrowsAsync<DbUpdateException>(
-            () => context.SaveChangesAsync());
+		// Assert - Should throw due to unique key constraint violation
+		var exception = await Assert.ThrowsAsync<DbUpdateException>(
+			() => context.SaveChangesAsync());
 
-        // Verify it's a Cosmos conflict (409) error - check StatusCode, not message string
-        AssertCosmosConflict(exception);
-    }
+		// Verify it's a Cosmos conflict (409) error - check StatusCode, not message string
+		AssertCosmosConflict(exception);
+	}
 
-    [Fact]
-    public async Task ShiftTemplates_DuplicateTemplateName_DifferentUsers_Succeeds()
-    {
-        // Arrange - Unique key is scoped to partition, so different users can have same template name
-        var userId1 = $"db-unique-user1-{Guid.NewGuid():N}";
-        var userId2 = $"db-unique-user2-{Guid.NewGuid():N}";
-        await using var context = _fixture.CreateContext();
+	[Fact]
+	public async Task ShiftTemplates_DuplicateTemplateName_DifferentUsers_Succeeds()
+	{
+		// Arrange - Unique key is scoped to partition, so different users can have same template name
+		var userId1 = $"db-unique-user1-{Guid.NewGuid():N}";
+		var userId2 = $"db-unique-user2-{Guid.NewGuid():N}";
+		await using var context = _fixture.CreateContext();
 
-        var template1 = new ShiftTemplate
-        {
-            Id = Guid.NewGuid(),
-            UserId = userId1,
-            TemplateName = "Shared Template Name",
-            Workplace = "Workplace",
-            PayRate = 15.00m,
-            StartTime = new DateTime(2024, 1, 1, 9, 0, 0, DateTimeKind.Utc),
-            EndTime = new DateTime(2024, 1, 1, 17, 0, 0, DateTimeKind.Utc),
-            UnpaidBreaks = []
-        };
+		var template1 = new ShiftTemplate
+		{
+			Id = Guid.NewGuid(),
+			UserId = userId1,
+			TemplateName = "Shared Template Name",
+			Workplace = "Workplace",
+			PayRate = 15.00m,
+			StartTime = new DateTime(2024, 1, 1, 9, 0, 0, DateTimeKind.Utc),
+			EndTime = new DateTime(2024, 1, 1, 17, 0, 0, DateTimeKind.Utc),
+			UnpaidBreaks = []
+		};
 
-        var template2 = new ShiftTemplate
-        {
-            Id = Guid.NewGuid(),
-            UserId = userId2, // Different user (different partition)
-            TemplateName = "Shared Template Name", // Same name - OK in different partition
-            Workplace = "Workplace",
-            PayRate = 20.00m,
-            StartTime = new DateTime(2024, 1, 1, 10, 0, 0, DateTimeKind.Utc),
-            EndTime = new DateTime(2024, 1, 1, 18, 0, 0, DateTimeKind.Utc),
-            UnpaidBreaks = []
-        };
+		var template2 = new ShiftTemplate
+		{
+			Id = Guid.NewGuid(),
+			UserId = userId2, // Different user (different partition)
+			TemplateName = "Shared Template Name", // Same name - OK in different partition
+			Workplace = "Workplace",
+			PayRate = 20.00m,
+			StartTime = new DateTime(2024, 1, 1, 10, 0, 0, DateTimeKind.Utc),
+			EndTime = new DateTime(2024, 1, 1, 18, 0, 0, DateTimeKind.Utc),
+			UnpaidBreaks = []
+		};
 
-        // Act & Assert - Should succeed
-        context.ShiftTemplates.Add(template1);
-        await context.SaveChangesAsync();
+		// Act & Assert - Should succeed
+		context.ShiftTemplates.Add(template1);
+		await context.SaveChangesAsync();
 
-        context.ShiftTemplates.Add(template2);
-        await context.SaveChangesAsync(); // Should not throw
+		context.ShiftTemplates.Add(template2);
+		await context.SaveChangesAsync(); // Should not throw
 
-        // Verify both exist
-        var count1 = await context.ShiftTemplates.CountAsync(t => t.UserId == userId1);
-        var count2 = await context.ShiftTemplates.CountAsync(t => t.UserId == userId2);
-        Assert.Equal(1, count1);
-        Assert.Equal(1, count2);
-    }
+		// Verify both exist
+		var count1 = await context.ShiftTemplates.CountAsync(t => t.UserId == userId1);
+		var count2 = await context.ShiftTemplates.CountAsync(t => t.UserId == userId2);
+		Assert.Equal(1, count1);
+		Assert.Equal(1, count2);
+	}
 
-    #endregion
+	#endregion
 
-    #region Unique Key Constraint Tests - WorkInfos
+	#region Unique Key Constraint Tests - WorkInfos
 
-    [Fact]
-    public async Task WorkInfos_DuplicateWorkplace_SameUser_ThrowsConflict()
-    {
-        // Arrange - Unique key on /Workplace within partition (userId)
-        var userId = $"db-workinfo-unique-{Guid.NewGuid():N}";
-        await using var context = _fixture.CreateContext();
+	[Fact]
+	public async Task WorkInfos_DuplicateWorkplace_SameUser_ThrowsConflict()
+	{
+		// Arrange - Unique key on /Workplace within partition (userId)
+		var userId = $"db-workinfo-unique-{Guid.NewGuid():N}";
+		await using var context = _fixture.CreateContext();
 
-        var workInfo1 = new WorkInfo
-        {
-            Id = $"workinfo-{Guid.NewGuid():N}",
-            UserId = userId,
-            Workplace = "Duplicate Workplace",
-            PayRates = [15.00m]
-        };
+		var workInfo1 = new WorkInfo
+		{
+			Id = $"workinfo-{Guid.NewGuid():N}",
+			UserId = userId,
+			Workplace = "Duplicate Workplace",
+			PayRates = [15.00m]
+		};
 
-        var workInfo2 = new WorkInfo
-        {
-            Id = $"workinfo-{Guid.NewGuid():N}", // Different ID
-            UserId = userId,     // Same user (partition)
-            Workplace = "Duplicate Workplace", // Same workplace - should violate unique key
-            PayRates = [20.00m]
-        };
+		var workInfo2 = new WorkInfo
+		{
+			Id = $"workinfo-{Guid.NewGuid():N}", // Different ID
+			UserId = userId,     // Same user (partition)
+			Workplace = "Duplicate Workplace", // Same workplace - should violate unique key
+			PayRates = [20.00m]
+		};
 
-        // Act
-        context.WorkInfos.Add(workInfo1);
-        await context.SaveChangesAsync();
+		// Act
+		context.WorkInfos.Add(workInfo1);
+		await context.SaveChangesAsync();
 
-        context.WorkInfos.Add(workInfo2);
+		context.WorkInfos.Add(workInfo2);
 
-        // Assert - Should throw due to unique key constraint violation
-        var exception = await Assert.ThrowsAsync<DbUpdateException>(
-            () => context.SaveChangesAsync());
+		// Assert - Should throw due to unique key constraint violation
+		var exception = await Assert.ThrowsAsync<DbUpdateException>(
+			() => context.SaveChangesAsync());
 
-        // Verify it's a Cosmos conflict (409) error - check StatusCode, not message string
-        AssertCosmosConflict(exception);
-    }
+		// Verify it's a Cosmos conflict (409) error - check StatusCode, not message string
+		AssertCosmosConflict(exception);
+	}
 
-    [Fact]
-    public async Task WorkInfos_DuplicateWorkplace_DifferentUsers_Succeeds()
-    {
-        // Arrange - Unique key is scoped to partition, so different users can have same workplace
-        var userId1 = $"db-workinfo-user1-{Guid.NewGuid():N}";
-        var userId2 = $"db-workinfo-user2-{Guid.NewGuid():N}";
-        await using var context = _fixture.CreateContext();
+	[Fact]
+	public async Task WorkInfos_DuplicateWorkplace_DifferentUsers_Succeeds()
+	{
+		// Arrange - Unique key is scoped to partition, so different users can have same workplace
+		var userId1 = $"db-workinfo-user1-{Guid.NewGuid():N}";
+		var userId2 = $"db-workinfo-user2-{Guid.NewGuid():N}";
+		await using var context = _fixture.CreateContext();
 
-        var workInfo1 = new WorkInfo
-        {
-            Id = $"workinfo-{Guid.NewGuid():N}",
-            UserId = userId1,
-            Workplace = "Shared Workplace",
-            PayRates = [15.00m]
-        };
+		var workInfo1 = new WorkInfo
+		{
+			Id = $"workinfo-{Guid.NewGuid():N}",
+			UserId = userId1,
+			Workplace = "Shared Workplace",
+			PayRates = [15.00m]
+		};
 
-        var workInfo2 = new WorkInfo
-        {
-            Id = $"workinfo-{Guid.NewGuid():N}",
-            UserId = userId2, // Different user (different partition)
-            Workplace = "Shared Workplace", // Same workplace - OK in different partition
-            PayRates = [20.00m]
-        };
+		var workInfo2 = new WorkInfo
+		{
+			Id = $"workinfo-{Guid.NewGuid():N}",
+			UserId = userId2, // Different user (different partition)
+			Workplace = "Shared Workplace", // Same workplace - OK in different partition
+			PayRates = [20.00m]
+		};
 
-        // Act & Assert - Should succeed
-        context.WorkInfos.Add(workInfo1);
-        await context.SaveChangesAsync();
+		// Act & Assert - Should succeed
+		context.WorkInfos.Add(workInfo1);
+		await context.SaveChangesAsync();
 
-        context.WorkInfos.Add(workInfo2);
-        await context.SaveChangesAsync(); // Should not throw
+		context.WorkInfos.Add(workInfo2);
+		await context.SaveChangesAsync(); // Should not throw
 
-        // Verify both exist
-        var count1 = await context.WorkInfos.CountAsync(w => w.UserId == userId1);
-        var count2 = await context.WorkInfos.CountAsync(w => w.UserId == userId2);
-        Assert.Equal(1, count1);
-        Assert.Equal(1, count2);
-    }
+		// Verify both exist
+		var count1 = await context.WorkInfos.CountAsync(w => w.UserId == userId1);
+		var count2 = await context.WorkInfos.CountAsync(w => w.UserId == userId2);
+		Assert.Equal(1, count1);
+		Assert.Equal(1, count2);
+	}
 
-    #endregion
+	#endregion
 
-    #region Partition Key Tests
+	#region Partition Key Tests
 
-    [Fact]
-    public async Task Shifts_HierarchicalPartitionKey_WorksCorrectly()
-    {
-        // Arrange - Shifts use hierarchical partition key: /UserId, /YearMonth, /Day
-        var userId = $"db-partition-test-{Guid.NewGuid():N}";
-        await using var context = _fixture.CreateContext();
+	[Fact]
+	public async Task Shifts_HierarchicalPartitionKey_WorksCorrectly()
+	{
+		// Arrange - Shifts use hierarchical partition key: /UserId, /YearMonth, /Day
+		var userId = $"db-partition-test-{Guid.NewGuid():N}";
+		await using var context = _fixture.CreateContext();
 
-        var shift1 = new Shift
-        {
-            Id = Guid.NewGuid(),
-            UserId = userId,
-            Workplace = "Test",
-            PayRate = 20.00m,
-            StartTime = new DateTime(2024, 6, 15, 9, 0, 0, DateTimeKind.Utc), // June 15
-            EndTime = new DateTime(2024, 6, 15, 17, 0, 0, DateTimeKind.Utc),
-            UnpaidBreaks = []
-        };
+		var shift1 = new Shift
+		{
+			Id = Guid.NewGuid(),
+			UserId = userId,
+			Workplace = "Test",
+			PayRate = 20.00m,
+			StartTime = new DateTime(2024, 6, 15, 9, 0, 0, DateTimeKind.Utc), // June 15
+			EndTime = new DateTime(2024, 6, 15, 17, 0, 0, DateTimeKind.Utc),
+			UnpaidBreaks = []
+		};
 
-        var shift2 = new Shift
-        {
-            Id = Guid.NewGuid(),
-            UserId = userId,
-            Workplace = "Test",
-            PayRate = 22.00m,
-            StartTime = new DateTime(2024, 7, 20, 9, 0, 0, DateTimeKind.Utc), // July 20 (different partition)
-            EndTime = new DateTime(2024, 7, 20, 17, 0, 0, DateTimeKind.Utc),
-            UnpaidBreaks = []
-        };
+		var shift2 = new Shift
+		{
+			Id = Guid.NewGuid(),
+			UserId = userId,
+			Workplace = "Test",
+			PayRate = 22.00m,
+			StartTime = new DateTime(2024, 7, 20, 9, 0, 0, DateTimeKind.Utc), // July 20 (different partition)
+			EndTime = new DateTime(2024, 7, 20, 17, 0, 0, DateTimeKind.Utc),
+			UnpaidBreaks = []
+		};
 
-        // Act
-        context.Shifts.Add(shift1);
-        context.Shifts.Add(shift2);
-        await context.SaveChangesAsync();
+		// Act
+		context.Shifts.Add(shift1);
+		context.Shifts.Add(shift2);
+		await context.SaveChangesAsync();
 
-        // Assert - Both should be queryable
-        var allShifts = await context.Shifts
-            .Where(s => s.UserId == userId)
-            .ToListAsync();
+		// Assert - Both should be queryable
+		var allShifts = await context.Shifts
+			.Where(s => s.UserId == userId)
+			.ToListAsync();
 
-        Assert.Equal(2, allShifts.Count);
-        Assert.Contains(allShifts, s => s.YearMonth == "2024-06" && s.Day == 15);
-        Assert.Contains(allShifts, s => s.YearMonth == "2024-07" && s.Day == 20);
-    }
+		Assert.Equal(2, allShifts.Count);
+		Assert.Contains(allShifts, s => s.YearMonth == "2024-06" && s.Day == 15);
+		Assert.Contains(allShifts, s => s.YearMonth == "2024-07" && s.Day == 20);
+	}
 
-    #endregion
+	#endregion
 
-    #region ETag Concurrency Tests
+	#region ETag Concurrency Tests
 
-    [Fact]
-    public async Task Shifts_ETagConcurrency_IsEnabled()
-    {
-        // Arrange - This test verifies that EF Core concurrency control with ETags is working
-        // The ETag property may not be directly visible but concurrency checks should still work
-        var userId = $"db-etag-test-{Guid.NewGuid():N}";
-        var shiftId = Guid.NewGuid();
-        var startTime = new DateTime(2024, 8, 1, 9, 0, 0, DateTimeKind.Utc);
+	[Fact]
+	public async Task Shifts_ETagConcurrency_IsEnabled()
+	{
+		// Arrange - This test verifies that EF Core concurrency control with ETags is working
+		// The ETag property may not be directly visible but concurrency checks should still work
+		var userId = $"db-etag-test-{Guid.NewGuid():N}";
+		var shiftId = Guid.NewGuid();
+		var startTime = new DateTime(2024, 8, 1, 9, 0, 0, DateTimeKind.Utc);
 
-        // Create the shift
-        await using (var createContext = _fixture.CreateContext())
-        {
-            var shift = new Shift
-            {
-                Id = shiftId,
-                UserId = userId,
-                Workplace = "ETag Test",
-                PayRate = 20.00m,
-                StartTime = startTime,
-                EndTime = new DateTime(2024, 8, 1, 17, 0, 0, DateTimeKind.Utc),
-                UnpaidBreaks = []
-            };
+		// Create the shift
+		await using (var createContext = _fixture.CreateContext())
+		{
+			var shift = new Shift
+			{
+				Id = shiftId,
+				UserId = userId,
+				Workplace = "ETag Test",
+				PayRate = 20.00m,
+				StartTime = startTime,
+				EndTime = new DateTime(2024, 8, 1, 17, 0, 0, DateTimeKind.Utc),
+				UnpaidBreaks = []
+			};
 
-            createContext.Shifts.Add(shift);
-            await createContext.SaveChangesAsync();
-        }
+			createContext.Shifts.Add(shift);
+			await createContext.SaveChangesAsync();
+		}
 
-        // Load in context1 (fresh context)
-        await using var context1 = _fixture.CreateContext();
-        var loaded1 = await context1.Shifts
-            .Where(s => s.Id == shiftId && s.UserId == userId)
-            .FirstOrDefaultAsync();
-        Assert.NotNull(loaded1);
+		// Load in context1 (fresh context)
+		await using var context1 = _fixture.CreateContext();
+		var loaded1 = await context1.Shifts
+			.Where(s => s.Id == shiftId && s.UserId == userId)
+			.FirstOrDefaultAsync();
+		Assert.NotNull(loaded1);
 
-        // Load in context2
-        await using var context2 = _fixture.CreateContext();
-        var loaded2 = await context2.Shifts
-            .Where(s => s.Id == shiftId && s.UserId == userId)
-            .FirstOrDefaultAsync();
-        Assert.NotNull(loaded2);
+		// Load in context2
+		await using var context2 = _fixture.CreateContext();
+		var loaded2 = await context2.Shifts
+			.Where(s => s.Id == shiftId && s.UserId == userId)
+			.FirstOrDefaultAsync();
+		Assert.NotNull(loaded2);
 
-        // Modify in context2 first - this changes the ETag in Cosmos DB
-        loaded2.PayRate = 25.00m;
-        await context2.SaveChangesAsync();
+		// Modify in context2 first - this changes the ETag in Cosmos DB
+		loaded2.PayRate = 25.00m;
+		await context2.SaveChangesAsync();
 
-        // Now try to modify in context1 (has stale ETag from when it was loaded)
-        loaded1.PayRate = 30.00m;
+		// Now try to modify in context1 (has stale ETag from when it was loaded)
+		loaded1.PayRate = 30.00m;
 
-        // Assert - Should throw DbUpdateConcurrencyException due to ETag mismatch
-        // This proves that UseETagConcurrency() is working
-        await Assert.ThrowsAsync<DbUpdateConcurrencyException>(
-            () => context1.SaveChangesAsync());
-    }
+		// Assert - Should throw DbUpdateConcurrencyException due to ETag mismatch
+		// This proves that UseETagConcurrency() is working
+		await Assert.ThrowsAsync<DbUpdateConcurrencyException>(
+			() => context1.SaveChangesAsync());
+	}
 
-    #endregion
+	#endregion
 
-    #region Helper Methods
+	#region Helper Methods
 
-    /// <summary>
-    /// Asserts that the exception is caused by a Cosmos DB conflict (HTTP 409).
-    /// Checks the actual StatusCode rather than relying on brittle string matching.
-    /// </summary>
-    private static void AssertCosmosConflict(DbUpdateException exception)
-    {
-        // Walk the exception chain to find CosmosException
-        var innerException = exception.InnerException;
-        while (innerException != null)
-        {
-            if (innerException is CosmosException cosmosException)
-            {
-                Assert.Equal(System.Net.HttpStatusCode.Conflict, cosmosException.StatusCode);
-                return;
-            }
-            innerException = innerException.InnerException;
-        }
+	/// <summary>
+	/// Asserts that the exception is caused by a Cosmos DB conflict (HTTP 409).
+	/// Checks the actual StatusCode rather than relying on brittle string matching.
+	/// </summary>
+	private static void AssertCosmosConflict(DbUpdateException exception)
+	{
+		// Walk the exception chain to find CosmosException
+		var innerException = exception.InnerException;
+		while (innerException != null)
+		{
+			if (innerException is CosmosException cosmosException)
+			{
+				Assert.Equal(System.Net.HttpStatusCode.Conflict, cosmosException.StatusCode);
+				return;
+			}
+			innerException = innerException.InnerException;
+		}
 
-        // If no CosmosException found, fail with helpful message
-        Assert.Fail($"Expected CosmosException with Conflict status, but inner exception was: {exception.InnerException?.GetType().Name ?? "null"}");
-    }
+		// If no CosmosException found, fail with helpful message
+		Assert.Fail($"Expected CosmosException with Conflict status, but inner exception was: {exception.InnerException?.GetType().Name ?? "null"}");
+	}
 
-    #endregion
+	#endregion
 }

--- a/ShiftPay_Backend.Tests/IntegrationTests.cs
+++ b/ShiftPay_Backend.Tests/IntegrationTests.cs
@@ -24,7 +24,7 @@ public class IntegrationTests : IAsyncLifetime
 	private HttpClient? _httpClient;
 	private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(60);
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		var appHost = await DistributedApplicationTestingBuilder
 			.CreateAsync<Projects.ShiftPay_Backend_AppHost>();
@@ -52,7 +52,7 @@ public class IntegrationTests : IAsyncLifetime
 			.WaitForResourceAsync("shiftpay-backend", KnownResourceStates.Running, cts.Token);
 	}
 
-	public async Task DisposeAsync()
+	public async ValueTask DisposeAsync()
 	{
 		_httpClient?.Dispose();
 		if (_app is not null)

--- a/ShiftPay_Backend.Tests/ShiftPay_Backend.Tests.csproj
+++ b/ShiftPay_Backend.Tests/ShiftPay_Backend.Tests.csproj
@@ -19,20 +19,14 @@
   <ItemGroup>
 	<PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.0" />
 	<PackageReference Include="Aspire.Hosting.Testing" Version="13.1.0" />
-	<PackageReference Include="coverlet.collector" Version="6.0.4">
-	  <PrivateAssets>all</PrivateAssets>
-	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	</PackageReference>
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
-	<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.56.0" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1" />
-	<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
+	<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.57.0" />
+	<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.2.0" />
 	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-	<PackageReference Include="xunit" Version="2.9.3" />
 	<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
+	<PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ShiftPay_Backend.Tests/ShiftsControllerTests.cs
+++ b/ShiftPay_Backend.Tests/ShiftsControllerTests.cs
@@ -4,21 +4,17 @@ using ShiftPay_Backend.Models;
 namespace ShiftPay_Backend.Tests;
 
 [Collection("CosmosDb")]
-public class ShiftsControllerTests : IAsyncLifetime
+public class ShiftsControllerTests
 {
 	private readonly CosmosDbTestFixture _fixture;
+
+	// Each test class instance gets a unique user ID to ensure test isolation
+	// Database is cleaned at the start of each test run, not after each test
 	private readonly string _testUserId = $"shifts-test-{Guid.NewGuid():N}";
 
 	public ShiftsControllerTests(CosmosDbTestFixture fixture)
 	{
 		_fixture = fixture;
-	}
-
-	public Task InitializeAsync() => Task.CompletedTask;
-
-	public async Task DisposeAsync()
-	{
-		await _fixture.CleanupUserDataAsync(_testUserId);
 	}
 
 	[Fact]


### PR DESCRIPTION
Introduces DatabaseInfrastructureTests to verify Cosmos DB containers, unique key constraints, partition keys, and ETag concurrency. Updates CosmosDbTestFixture to use a dedicated test database, delete and recreate the database at the start of each test run, and set up unique key policies for WorkInfos and ShiftTemplates. Refactors controller test classes to use per-class unique user IDs for test isolation, removing per-test cleanup. Adds and updates tests to verify unique key enforcement and user data isolation.