### PR TITLE
Refactor controllers to use ID instead of name in routes

### DIFF
--- a/ShiftPay_Backend.AppHost/ShiftPay_Backend.AppHost.csproj
+++ b/ShiftPay_Backend.AppHost/ShiftPay_Backend.AppHost.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>

--- a/ShiftPay_Backend.ServiceDefaults/ShiftPay_Backend.ServiceDefaults.csproj
+++ b/ShiftPay_Backend.ServiceDefaults/ShiftPay_Backend.ServiceDefaults.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>

--- a/ShiftPay_Backend.Tests/DatabaseInfrastructureTests.cs
+++ b/ShiftPay_Backend.Tests/DatabaseInfrastructureTests.cs
@@ -161,7 +161,7 @@ public class DatabaseInfrastructureTests
 
 		var workInfo1 = new WorkInfo
 		{
-			Id = $"workinfo-{Guid.NewGuid():N}",
+			Id = Guid.NewGuid(),
 			UserId = userId,
 			Workplace = "Duplicate Workplace",
 			PayRates = [15.00m]
@@ -169,7 +169,7 @@ public class DatabaseInfrastructureTests
 
 		var workInfo2 = new WorkInfo
 		{
-			Id = $"workinfo-{Guid.NewGuid():N}", // Different ID
+			Id = Guid.NewGuid(), // Different ID
 			UserId = userId,     // Same user (partition)
 			Workplace = "Duplicate Workplace", // Same workplace - should violate unique key
 			PayRates = [20.00m]
@@ -199,7 +199,7 @@ public class DatabaseInfrastructureTests
 
 		var workInfo1 = new WorkInfo
 		{
-			Id = $"workinfo-{Guid.NewGuid():N}",
+			Id = Guid.NewGuid(),
 			UserId = userId1,
 			Workplace = "Shared Workplace",
 			PayRates = [15.00m]
@@ -207,7 +207,7 @@ public class DatabaseInfrastructureTests
 
 		var workInfo2 = new WorkInfo
 		{
-			Id = $"workinfo-{Guid.NewGuid():N}",
+			Id = Guid.NewGuid(),
 			UserId = userId2, // Different user (different partition)
 			Workplace = "Shared Workplace", // Same workplace - OK in different partition
 			PayRates = [20.00m]

--- a/ShiftPay_Backend.Tests/WorkInfosControllerTests.cs
+++ b/ShiftPay_Backend.Tests/WorkInfosControllerTests.cs
@@ -52,6 +52,7 @@ public class WorkInfosControllerTests
 		// Assert
 		var createdResult = Assert.IsType<CreatedAtActionResult>(result.Result);
 		var createdWorkInfo = Assert.IsType<WorkInfoDTO>(createdResult.Value);
+		Assert.True(createdWorkInfo.Id.HasValue);
 		Assert.Equal(workInfoDto.Workplace, createdWorkInfo.Workplace);
 		Assert.Equal(workInfoDto.PayRates.Count, createdWorkInfo.PayRates.Count);
 	}
@@ -103,8 +104,11 @@ public class WorkInfosControllerTests
 			Workplace = "Test Store",
 			PayRates = [16.50m]
 		};
-		await controller.PostWorkInfo(workInfoDto);
-		var workInfoId = WorkInfo.CreateId(workInfoDto.Workplace);
+		var createdResult = await controller.PostWorkInfo(workInfoDto);
+		var createdAt = Assert.IsType<CreatedAtActionResult>(createdResult.Result);
+		var createdWorkInfo = Assert.IsType<WorkInfoDTO>(createdAt.Value);
+		Assert.True(createdWorkInfo.Id.HasValue);
+		var workInfoId = createdWorkInfo.Id.Value;
 
 		// Act
 		var result = await controller.GetWorkInfo(workInfoId);
@@ -125,14 +129,14 @@ public class WorkInfosControllerTests
 		var controller = ControllerTestHelper.CreateWorkInfosController(context, _testUserId);
 
 		// Act
-		var result = await controller.GetWorkInfo(WorkInfo.CreateId("NonExistent Workplace"));
+		var result = await controller.GetWorkInfo(Guid.NewGuid());
 
 		// Assert
 		Assert.IsType<NotFoundResult>(result.Result);
 	}
 
 	[Fact]
-	public async Task GetWorkInfo_WithSpecialCharactersInId_ReturnsWorkInfo()
+	public async Task GetWorkInfo_WithValidId_ReturnsWorkInfo()
 	{
 		// Arrange
 		await using var context = _fixture.CreateContext();
@@ -143,8 +147,11 @@ public class WorkInfosControllerTests
 			Workplace = "Joe's Coffee & Tea",
 			PayRates = [17.00m]
 		};
-		await controller.PostWorkInfo(workInfoDto);
-		var workInfoId = WorkInfo.CreateId(workInfoDto.Workplace);
+		var createdResult = await controller.PostWorkInfo(workInfoDto);
+		var createdAt = Assert.IsType<CreatedAtActionResult>(createdResult.Result);
+		var createdWorkInfo = Assert.IsType<WorkInfoDTO>(createdAt.Value);
+		Assert.True(createdWorkInfo.Id.HasValue);
+		var workInfoId = createdWorkInfo.Id.Value;
 
 		// Act
 		var result = await controller.GetWorkInfo(workInfoId);
@@ -167,8 +174,11 @@ public class WorkInfosControllerTests
 			Workplace = "Workplace To Delete",
 			PayRates = [15.00m]
 		};
-		await controller.PostWorkInfo(workInfoDto);
-		var workInfoId = WorkInfo.CreateId(workInfoDto.Workplace);
+		var createdResult = await controller.PostWorkInfo(workInfoDto);
+		var createdAt = Assert.IsType<CreatedAtActionResult>(createdResult.Result);
+		var createdWorkInfo = Assert.IsType<WorkInfoDTO>(createdAt.Value);
+		Assert.True(createdWorkInfo.Id.HasValue);
+		var workInfoId = createdWorkInfo.Id.Value;
 
 		// Act
 		var result = await controller.DeleteWorkInfo(workInfoId, null);
@@ -193,8 +203,11 @@ public class WorkInfosControllerTests
 			Workplace = "Multi Rate Workplace",
 			PayRates = [15.00m, 18.00m, 20.00m]
 		};
-		await controller.PostWorkInfo(workInfoDto);
-		var workInfoId = WorkInfo.CreateId(workInfoDto.Workplace);
+		var createdResult = await controller.PostWorkInfo(workInfoDto);
+		var createdAt = Assert.IsType<CreatedAtActionResult>(createdResult.Result);
+		var createdWorkInfo = Assert.IsType<WorkInfoDTO>(createdAt.Value);
+		Assert.True(createdWorkInfo.Id.HasValue);
+		var workInfoId = createdWorkInfo.Id.Value;
 
 		// Act - delete only the 18.00m pay rate
 		var result = await controller.DeleteWorkInfo(workInfoId, 18.00m);
@@ -220,7 +233,7 @@ public class WorkInfosControllerTests
 		var controller = ControllerTestHelper.CreateWorkInfosController(context, _testUserId);
 
 		// Act - deleting non-existent id without payRate parameter
-		var result = await controller.DeleteWorkInfo(WorkInfo.CreateId("NonExistent"), null);
+		var result = await controller.DeleteWorkInfo(Guid.NewGuid(), null);
 
 		// Assert - returns NoContent even if not found (idempotent delete)
 		Assert.IsType<NoContentResult>(result);
@@ -234,7 +247,7 @@ public class WorkInfosControllerTests
 		var controller = ControllerTestHelper.CreateWorkInfosController(context, _testUserId);
 
 		// Act - trying to delete pay rate from non-existent id
-		var result = await controller.DeleteWorkInfo(WorkInfo.CreateId("NonExistent"), 15.00m);
+		var result = await controller.DeleteWorkInfo(Guid.NewGuid(), 15.00m);
 
 		// Assert
 		Assert.IsType<NotFoundResult>(result);
@@ -261,14 +274,14 @@ public class WorkInfosControllerTests
 	}
 
 	[Fact]
-	public async Task GetWorkInfo_WithEmptyWorkplace_ReturnsBadRequest()
+	public async Task GetWorkInfo_WithEmptyId_ReturnsBadRequest()
 	{
 		// Arrange
 		await using var context = _fixture.CreateContext();
 		var controller = ControllerTestHelper.CreateWorkInfosController(context, _testUserId);
 
 		// Act
-		var result = await controller.GetWorkInfo("   ");
+		var result = await controller.GetWorkInfo(Guid.Empty);
 
 		// Assert
 		Assert.IsType<BadRequestObjectResult>(result.Result);
@@ -326,8 +339,11 @@ public class WorkInfosControllerTests
 			Workplace = "Test Workplace",
 			PayRates = [15.00m, 20.00m]
 		};
-		await controller.PostWorkInfo(workInfoDto);
-		var workInfoId = WorkInfo.CreateId(workInfoDto.Workplace);
+		var createdResult = await controller.PostWorkInfo(workInfoDto);
+		var createdAt = Assert.IsType<CreatedAtActionResult>(createdResult.Result);
+		var createdWorkInfo = Assert.IsType<WorkInfoDTO>(createdAt.Value);
+		Assert.True(createdWorkInfo.Id.HasValue);
+		var workInfoId = createdWorkInfo.Id.Value;
 
 		// Act - try to delete a pay rate that doesn't exist
 		var result = await controller.DeleteWorkInfo(workInfoId, 999.00m);
@@ -343,14 +359,14 @@ public class WorkInfosControllerTests
 	}
 
 	[Fact]
-	public async Task DeleteWorkInfo_WithEmptyWorkplace_ReturnsBadRequest()
+	public async Task DeleteWorkInfo_WithEmptyId_ReturnsBadRequest()
 	{
 		// Arrange
 		await using var context = _fixture.CreateContext();
 		var controller = ControllerTestHelper.CreateWorkInfosController(context, _testUserId);
 
 		// Act
-		var result = await controller.DeleteWorkInfo("   ", null);
+		var result = await controller.DeleteWorkInfo(Guid.Empty, null);
 
 		// Assert
 		Assert.IsType<BadRequestObjectResult>(result);

--- a/ShiftPay_Backend.Tests/WorkInfosControllerTests.cs
+++ b/ShiftPay_Backend.Tests/WorkInfosControllerTests.cs
@@ -69,10 +69,14 @@ public class WorkInfosControllerTests
 			Workplace = "Test Restaurant",
 			PayRates = [15.00m, 18.00m]
 		};
-		await controller.PostWorkInfo(initialWorkInfo);
+		var initialResult = await controller.PostWorkInfo(initialWorkInfo);
+		var initialCreated = Assert.IsType<CreatedAtActionResult>(initialResult.Result);
+		var initialWorkInfoResult = Assert.IsType<WorkInfoDTO>(initialCreated.Value);
+		Assert.True(initialWorkInfoResult.Id.HasValue);
 
 		var additionalWorkInfo = new WorkInfoDTO
 		{
+			Id = initialWorkInfoResult.Id,
 			Workplace = "Test Restaurant",
 			PayRates = [18.00m, 20.00m, 22.00m] // 18.00m is duplicate
 		};
@@ -380,15 +384,19 @@ public class WorkInfosControllerTests
 		var controller = ControllerTestHelper.CreateWorkInfosController(context, _testUserId);
 
 		// Create initial work info
-		await controller.PostWorkInfo(new WorkInfoDTO
+		var initialResult = await controller.PostWorkInfo(new WorkInfoDTO
 		{
 			Workplace = "Merge Test",
 			PayRates = [15.00m]
 		});
+		var initialCreated = Assert.IsType<CreatedAtActionResult>(initialResult.Result);
+		var initialWorkInfoResult = Assert.IsType<WorkInfoDTO>(initialCreated.Value);
+		Assert.True(initialWorkInfoResult.Id.HasValue);
 
 		// Add more pay rates
 		var result = await controller.PostWorkInfo(new WorkInfoDTO
 		{
+			Id = initialWorkInfoResult.Id,
 			Workplace = "Merge Test",
 			PayRates = [20.00m, 25.00m]
 		});

--- a/ShiftPay_Backend/Controllers/ShiftTemplatesController.cs
+++ b/ShiftPay_Backend/Controllers/ShiftTemplatesController.cs
@@ -38,14 +38,13 @@ namespace ShiftPay_Backend.Controllers
 			return Ok(shiftTemplates.Select(st => st.ToDTO()));
 		}
 
-		// GET: api/ShiftTemplates/KFC-12345
-		[HttpGet("{templateName}")]
-		public async Task<ActionResult<ShiftTemplateDTO>> GetShiftTemplate(string templateName)
+		// GET: api/ShiftTemplates/{id}
+		[HttpGet("{id:guid}")]
+		public async Task<ActionResult<ShiftTemplateDTO>> GetShiftTemplate(Guid id)
 		{
-			templateName = Uri.UnescapeDataString(templateName.Trim());
-			if (string.IsNullOrEmpty(templateName))
+			if (id == Guid.Empty)
 			{
-				return BadRequest("Template name cannot be empty.");
+				return BadRequest("Id cannot be empty.");
 			}
 
 			var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
@@ -56,9 +55,9 @@ namespace ShiftPay_Backend.Controllers
 
 			var shiftTemplate = await _context.ShiftTemplates
 				.WithPartitionKey(userId)
-				.FirstOrDefaultAsync(st => st.TemplateName == templateName);
+				.FirstOrDefaultAsync(st => st.Id == id);
 
-			return shiftTemplate != default ? Ok(shiftTemplate.ToDTO()) : NotFound("No matching shift found.");
+			return shiftTemplate != default ? Ok(shiftTemplate.ToDTO()) : NotFound("No matching shift template found.");
 		}
 
 		// POST: api/ShiftTemplates
@@ -118,17 +117,16 @@ namespace ShiftPay_Backend.Controllers
 				return Conflict();
 			}
 
-			return CreatedAtAction(nameof(GetShiftTemplate), new { templateName = receivedTemplate.TemplateName }, receivedTemplate.ToDTO());
+			return CreatedAtAction(nameof(GetShiftTemplate), new { id = receivedTemplate.Id }, receivedTemplate.ToDTO());
 		}
 
-		// DELETE: api/ShiftTemplates/KFC-12345
-		[HttpDelete("{templateName}")]
-		public async Task<IActionResult> DeleteShiftTemplate(string templateName)
+		// DELETE: api/ShiftTemplates/{id}
+		[HttpDelete("{id:guid}")]
+		public async Task<IActionResult> DeleteShiftTemplate(Guid id)
 		{
-			templateName = Uri.UnescapeDataString(templateName.Trim());
-			if (string.IsNullOrEmpty(templateName))
+			if (id == Guid.Empty)
 			{
-				return BadRequest("Template name cannot be empty.");
+				return BadRequest("Id cannot be empty.");
 			}
 
 			var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
@@ -139,11 +137,11 @@ namespace ShiftPay_Backend.Controllers
 
 			var shiftTemplate = await _context.ShiftTemplates
 				.WithPartitionKey(userId)
-				.FirstOrDefaultAsync(st => st.TemplateName == templateName);
+				.FirstOrDefaultAsync(st => st.Id == id);
 
 			if (shiftTemplate == default)
 			{
-				return NotFound("No matching shift template found to delete.");
+				return NotFound("No matching shift template found.");
 			}
 
 			_context.ShiftTemplates.Remove(shiftTemplate);

--- a/ShiftPay_Backend/Controllers/ShiftTemplatesController.cs
+++ b/ShiftPay_Backend/Controllers/ShiftTemplatesController.cs
@@ -53,9 +53,7 @@ namespace ShiftPay_Backend.Controllers
 				return Unauthorized("User ID is missing.");
 			}
 
-			var shiftTemplate = await _context.ShiftTemplates
-				.WithPartitionKey(userId)
-				.FirstOrDefaultAsync(st => st.Id == id);
+			var shiftTemplate = await _context.ShiftTemplates.FindAsync(id, userId);
 
 			return shiftTemplate != default ? Ok(shiftTemplate.ToDTO()) : NotFound("No matching shift template found.");
 		}
@@ -135,9 +133,7 @@ namespace ShiftPay_Backend.Controllers
 				return Unauthorized("User ID is missing.");
 			}
 
-			var shiftTemplate = await _context.ShiftTemplates
-				.WithPartitionKey(userId)
-				.FirstOrDefaultAsync(st => st.Id == id);
+			var shiftTemplate = await _context.ShiftTemplates.FindAsync(id, userId);
 
 			if (shiftTemplate == default)
 			{

--- a/ShiftPay_Backend/Controllers/ShiftsController.cs
+++ b/ShiftPay_Backend/Controllers/ShiftsController.cs
@@ -51,7 +51,7 @@ namespace ShiftPay_Backend.Controllers
 		}
 
 		// GET: api/Shifts/abc-123
-		[HttpGet("{id}")]
+		[HttpGet("{id:guid}")]
 		public async Task<ActionResult<ShiftDTO>> GetShift(Guid id)
 		{
 			var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
@@ -67,7 +67,7 @@ namespace ShiftPay_Backend.Controllers
 
 
 		// PUT: api/Shifts/abc-123
-		[HttpPut("{id}")]
+		[HttpPut("{id:guid}")]
 		public async Task<ActionResult<ShiftDTO>> PutShift(Guid id, ShiftDTO receivedShiftDTO)
 		{
 			var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
@@ -296,7 +296,7 @@ namespace ShiftPay_Backend.Controllers
 		}
 
 		// DELETE: api/Shifts/5
-		[HttpDelete("{id}")]
+		[HttpDelete("{id:guid}")]
 		public async Task<IActionResult> DeleteShift(Guid id)
 		{
 			var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;

--- a/ShiftPay_Backend/Controllers/WorkInfosController.cs
+++ b/ShiftPay_Backend/Controllers/WorkInfosController.cs
@@ -38,30 +38,19 @@ namespace ShiftPay_Backend.Controllers
 			return Ok(workInfos.Select(workInfo => workInfo.ToDTO()));
 		}
 
-		// GET: api/WorkInfos/KFC
-		[HttpGet("{workplace}")]
-		public async Task<ActionResult<WorkInfoDTO>> GetWorkInfo(string workplace)
+		// GET: api/WorkInfos/{id}
+		[HttpGet("{id}")]
+		public async Task<ActionResult<WorkInfoDTO>> GetWorkInfo(string id)
 		{
-			workplace = Uri.UnescapeDataString(workplace.Trim());
-			if (string.IsNullOrEmpty(workplace))
+			if (string.IsNullOrWhiteSpace(id))
 			{
-				return BadRequest("Workplace cannot be empty.");
+				return BadRequest("Id cannot be empty.");
 			}
 
 			var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
 			if (string.IsNullOrEmpty(userId))
 			{
 				return Unauthorized("User ID is missing.");
-			}
-
-			string id;
-			try
-			{
-				id = WorkInfo.CreateId(workplace);
-			}
-			catch (ArgumentException ex)
-			{
-				return BadRequest(ex.Message);
 			}
 
 			// https://learn.microsoft.com/en-us/azure/cosmos-db/optimize-cost-reads-writes
@@ -114,9 +103,9 @@ namespace ShiftPay_Backend.Controllers
 					return BadRequest(ex.Message);
 				}
 
-				_context.WorkInfos.Add(workInfo);
+			_context.WorkInfos.Add(workInfo);
 				await _context.SaveChangesAsync();
-				return CreatedAtAction(nameof(GetWorkInfo), new { workplace = workInfo.Workplace }, workInfo.ToDTO());
+				return CreatedAtAction(nameof(GetWorkInfo), new { id = workInfo.Id }, workInfo.ToDTO());
 			}
 
 			workInfo.PayRates = workInfo.PayRates.Union(workInfoDto.PayRates).ToHashSet().ToList();
@@ -135,30 +124,19 @@ namespace ShiftPay_Backend.Controllers
 			return Ok(workInfo.ToDTO());
 		}
 
-		// DELETE: api/WorkInfos/KFC
-		[HttpDelete("{workplace}")]
-		public async Task<IActionResult> DeleteWorkInfo(string workplace, decimal? payRate)
+		// DELETE: api/WorkInfos/{id}
+		[HttpDelete("{id}")]
+		public async Task<IActionResult> DeleteWorkInfo(string id, decimal? payRate)
 		{
-			workplace = Uri.UnescapeDataString(workplace.Trim());
-			if (string.IsNullOrEmpty(workplace))
+			if (string.IsNullOrWhiteSpace(id))
 			{
-				return BadRequest("Workplace cannot be empty.");
+				return BadRequest("Id cannot be empty.");
 			}
 
 			var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
 			if (string.IsNullOrEmpty(userId))
 			{
 				return Unauthorized("User ID is missing.");
-			}
-
-			string id;
-			try
-			{
-				id = WorkInfo.CreateId(workplace);
-			}
-			catch (ArgumentException ex)
-			{
-				return BadRequest(ex.Message);
 			}
 
 			// Cosmos point-read: (id, partitionKey)

--- a/ShiftPay_Backend/Controllers/WorkInfosController.cs
+++ b/ShiftPay_Backend/Controllers/WorkInfosController.cs
@@ -103,7 +103,7 @@ namespace ShiftPay_Backend.Controllers
 					return BadRequest(ex.Message);
 				}
 
-			_context.WorkInfos.Add(workInfo);
+				_context.WorkInfos.Add(workInfo);
 				await _context.SaveChangesAsync();
 				return CreatedAtAction(nameof(GetWorkInfo), new { id = workInfo.Id }, workInfo.ToDTO());
 			}

--- a/ShiftPay_Backend/Models/WorkInfo.cs
+++ b/ShiftPay_Backend/Models/WorkInfo.cs
@@ -5,7 +5,7 @@ namespace ShiftPay_Backend.Models
 	public class WorkInfo
 	{
 		[JsonProperty(PropertyName = "id")]
-		public required string Id { get; set; } // From Workplace, will be created via CreateId() in FromDTO() only
+		public required Guid Id { get; set; } = Guid.NewGuid();
 
 		public required string UserId { get; set; } // Partition Key
 
@@ -43,8 +43,9 @@ namespace ShiftPay_Backend.Models
 		{
 			return new WorkInfoDTO
 			{
+				Id = Id,
 				Workplace = this.Workplace,
-				PayRates = new List<decimal>(this.PayRates)
+				PayRates = new List<decimal>(this.PayRates ?? [])
 			};
 		}
 
@@ -52,25 +53,22 @@ namespace ShiftPay_Backend.Models
 		{
 			var workInfo = new WorkInfo
 			{
-				Id = CreateId(dto.Workplace),
+				Id = dto.Id ?? Guid.NewGuid(),
 				UserId = userId,
 				Workplace = dto.Workplace,
-				PayRates = new List<decimal>(dto.PayRates)
+				PayRates = new List<decimal>(dto.PayRates ?? [])
 			};
 
 			workInfo.Validate();
 			return workInfo;
 		}
 
-		public static string CreateId(string workplace)
-		{
-			ArgumentException.ThrowIfNullOrWhiteSpace(workplace);
-			return workplace.Trim();
-		}
 	}
 
 	public class WorkInfoDTO
 	{
+		public Guid? Id { get; set; }
+
 		public required string Workplace { get; set => field = value.Trim(); }
 
 		public List<decimal> PayRates { get; set; } = new List<decimal>();

--- a/ShiftPay_Backend/appsettings.Test.json
+++ b/ShiftPay_Backend/appsettings.Test.json
@@ -3,5 +3,6 @@
     "UseFake": true
   },
 
-  "CosmosDB-ConnectionString-Primary": "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
+  "CosmosDB-ConnectionString-Primary": "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
+  "DatabaseName": "ShiftPay_Test"
 }


### PR DESCRIPTION
ShiftTemplatesController and WorkInfosController now use unique IDs in route parameters for GET and DELETE actions instead of template/workplace names. All related tests have been updated to use IDs, improving reliability and removing the need for URL encoding of special characters. This change ensures more robust and consistent resource identification.